### PR TITLE
misc.h: only define min/max if not already defined

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -78,8 +78,13 @@ void debug_memdump(void *buf, int len, int L);
 #define lenof(x) ( (sizeof((x))) / (sizeof(*(x))))
 #endif
 
+#ifndef max
 inline int max(int x, int y) { return ( (x) > (y) ? (x) : (y) ); }
+#endif
+
+#ifndef min
 inline int min(int x, int y) { return ( (x) < (y) ? (x) : (y) ); }
+#endif
 
 #define GET_32BIT_LSB_FIRST(cp) \
   (((unsigned long)(unsigned char)(cp)[0]) | \


### PR DESCRIPTION
On some systems (eg. mingw) min/max is already a define.
