### PR TITLE
misc.h: fix min/max multiple definition for centos6

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -79,11 +79,11 @@ void debug_memdump(void *buf, int len, int L);
 #endif
 
 #ifndef max
-inline int max(int x, int y) { return ( (x) > (y) ? (x) : (y) ); }
+#define max(x,y) ( (x) > (y) ? (x) : (y) )
 #endif
 
 #ifndef min
-inline int min(int x, int y) { return ( (x) < (y) ? (x) : (y) ); }
+#define min(x,y) ( (x) < (y) ? (x) : (y) )
 #endif
 
 #define GET_32BIT_LSB_FIRST(cp) \


### PR DESCRIPTION
If the min/max is already a function, we will have multiple definitions.