### PR TITLE
terminal.c: Skip UCSWIDE when printing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtermcapparser (1.0.15) bionic; urgency=low
+
+  * Fixed wide character handling
+
+ -- Peter Zoltan Varga <peter.zoltan.varga@balabit.com>  Wed, 03 Apr 2019 12:00:00 +0000
+
 libtermcapparser (1.0.14) xenial; urgency=low
 
   * added target for macos

--- a/terminal.c
+++ b/terminal.c
@@ -5052,6 +5052,7 @@ static void do_paint(Terminal *term, Context ctx, int may_optimise)
 			dirty_run = TRUE;
 		    copy_termchar(term->disptext[i], j, d);
 		    term->disptext[i]->chars[j].attr = tattr;
+		    ch[ccount++] = (wchar_t) 0xDFFF;
 		}
 	    }
 	}

--- a/terminal.c
+++ b/terminal.c
@@ -5051,6 +5051,7 @@ static void do_paint(Terminal *term, Context ctx, int may_optimise)
 		    if (!termchars_equal(&term->disptext[i]->chars[j], d))
 			dirty_run = TRUE;
 		    copy_termchar(term->disptext[i], j, d);
+		    term->disptext[i]->chars[j].attr = tattr;
 		}
 	    }
 	}


### PR DESCRIPTION
If process the UCSWIDE special character (used to mark the right-hand
side of a wide character), the resulting std::wstring (ch) will contain
both the new CJK character and the previous character of any kind.
eg.: input is "l" first, then "파", the resulting wstring in the first
iteration is "l", in the second iteration is "l파" instead of "파".

References: jira PAM-8611